### PR TITLE
Kinda user friendly(?) changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Create Mojmap Jar
         run: ./gradlew createMojmapPaperclipJar --stacktrace
 
+      - name: Prepare release
+        run: |
+          zip build/libs/Prismarine-1.18.2-${{ env.workflow }}-jars.zip build/libs/*.jar
+          mv build/libs/Prismarine-paperclip-1.18.2-R0.1-SNAPSHOT-reobf.jar build/libs/Prismarine-1.18.2-${{ env.workflow }}.jar
+
       - name: Release Artifacts
         if: github.ref_name == env.branch
         uses: marvinpinto/action-automatic-releases@latest
@@ -56,7 +61,9 @@ jobs:
           title: "Release #${{ env.workflow }}"
           automatic_release_tag: release-${{ env.workflow }}
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          files: build/libs/*.jar
+          files: |
+            build/libs/Prismarine-1.18.2-${{ env.workflow }}-jars.zip
+            build/libs/Prismarine-1.18.2-${{ env.workflow }}.jar
           prerelease: false
           
       - name: Release Artifacts (Latest)
@@ -66,5 +73,7 @@ jobs:
           title: "Release #${{ env.workflow }}"
           automatic_release_tag: latest
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          files: build/libs/*.jar
+          files: |
+            build/libs/Prismarine-1.18.2-${{ env.workflow }}-jars.zip
+            build/libs/Prismarine-1.18.2-${{ env.workflow }}.jar
           prerelease: false


### PR DESCRIPTION
Release changes:
  Reobf paperclip jar renamed to Prismarine-1.18.2-${{ env.workflow }}.jar
  Every jar files are now stored in Prismarine-1.18.2-${{ env.workflow }}-jars.zip

idk why I did this tho