### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group = net.prismarineteam.prismarine
 version = 1.18.2-R0.1-SNAPSHOT
 
-paperCommit = 3eaf3a8f5e7ecd5d797ecc33445bd31c7cba6047
+paperCommit = 072f54c5f995de56e1c97dc15a4db4b97d688454
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/server/0002-Purpur-Server-Changes.patch
+++ b/patches/server/0002-Purpur-Server-Changes.patch
@@ -16254,13 +16254,13 @@ index 744d91546d1a810f60a43c15ed74b4158f341a4a..354538daefa603f6df5a139b6bff87db
                      }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index 7f83c9390823b42fc30d04e1d3222e2825eaad50..e837091037402e990f763903d851c2f70888ada7 100644
+index da7b4783da35bc08f48f2fe31c4d06f9fb5e160f..3e4d5862672a8445fae53519ff21c56971e2d403 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -71,7 +71,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
  public abstract class BlockBehaviour {
  
-     public static final Direction[] UPDATE_SHAPE_ORDER = new Direction[]{Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH, Direction.DOWN, Direction.UP}; // Paper - public
+     protected static final Direction[] UPDATE_SHAPE_ORDER = new Direction[]{Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH, Direction.DOWN, Direction.UP};
 -    protected final Material material;
 +    public final Material material; // Purpur - protected -> public
      public final boolean hasCollision;


### PR DESCRIPTION
I have a dream that Purpur team keep maintain previous version more longer


Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@ef5d95f Update alternate current patch (#7971)
PaperMC/Paper@072f54c Add ARMOR tag to MaterialTags (1.18.2) (#7880)